### PR TITLE
Update LICENSE and license headers in modified directories

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // Copyright 2014 The Chromium Authors. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -10,9 +11,9 @@
 // copyright notice, this list of conditions and the following disclaimer
 // in the documentation and/or other materials provided with the
 // distribution.
-//    * Neither the name of Google Inc. nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
+//    * Neither the name of Google Inc., Meta Platforms, Inc., nor the
+// names of its contributors may be used to endorse or promote products
+// derived from this software without specific prior written permission.
 //
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT

--- a/front_end/entrypoints/rn_inspector/rn_inspector.ts
+++ b/front_end/entrypoints/rn_inspector/rn_inspector.ts
@@ -1,6 +1,8 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // Copyright 2018 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 import '../shell/shell.js';
 import '../../panels/network/network-meta.js';
 import '../../panels/emulation/emulation-meta.js';

--- a/front_end/panels/rn_welcome/BUILD.gn
+++ b/front_end/panels/rn_welcome/BUILD.gn
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 # Copyright 2020 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/front_end/panels/rn_welcome/RNWelcome.ts
+++ b/front_end/panels/rn_welcome/RNWelcome.ts
@@ -1,3 +1,4 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // Copyright 2018 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/front_end/panels/rn_welcome/rnWelcome.css
+++ b/front_end/panels/rn_welcome/rnWelcome.css
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  * Copyright 2021 The Chromium Authors. All rights reserved.
  * Use of this source code is governed by a BSD-style license that can be
  * found in the LICENSE file.
@@ -12,7 +13,6 @@
   height: 100%;
   padding: 16px;
   text-align: center;
-  font-size: 1rem;
   background-color: var(--color-background-elevation-0);
 }
 

--- a/front_end/panels/rn_welcome/rn_welcome-meta.ts
+++ b/front_end/panels/rn_welcome/rn_welcome-meta.ts
@@ -1,3 +1,4 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // Copyright 2020 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/front_end/panels/rn_welcome/rn_welcome.ts
+++ b/front_end/panels/rn_welcome/rn_welcome.ts
@@ -1,3 +1,4 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.


### PR DESCRIPTION
## Summary

> NOTE: This includes #8 and will be rebased.

- Updates `LICENSE` to extend the BSD-style license from Google with `Meta Platforms, Inc.`, becoming the active license for this fork.
- Updates license headers for modified directories: `frontend/entrypoints/rn_inspector/`, `frontend/panels/rn_welcome/`.
- Updates `check_license_header` lint rule to check for this extended license header for a configured set of `META_CODE_PATHS`.

## Test plan

```
npm run check-lint-js
```