### PR TITLE
Remote Network panel from rn_inspector

### DIFF
--- a/front_end/entrypoints/rn_inspector/rn_inspector.ts
+++ b/front_end/entrypoints/rn_inspector/rn_inspector.ts
@@ -4,7 +4,6 @@
 // found in the LICENSE file.
 
 import '../shell/shell.js';
-import '../../panels/network/network-meta.js';
 import '../../panels/emulation/emulation-meta.js';
 import '../../panels/sensors/sensors-meta.js';
 import '../../panels/developer_resources/developer_resources-meta.js';


### PR DESCRIPTION
The Network panel won't be active in RN 0.73, so remove it.